### PR TITLE
Remove all ocurrences of layout:nil

### DIFF
--- a/source/_includes/custom/category_feed.xml
+++ b/source/_includes/custom/category_feed.xml
@@ -1,6 +1,3 @@
----
-layout: nil
----
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
 

--- a/source/atom.xml
+++ b/source/atom.xml
@@ -1,6 +1,3 @@
----
-layout: nil
----
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
 

--- a/source/robots.txt
+++ b/source/robots.txt
@@ -1,6 +1,3 @@
----
-layout: nil
----
 User-agent: *
 Disallow: 
 


### PR DESCRIPTION
Because nil was set as the layout for a file (which was the case
with some of the xml in the theme), whenever the website was
generated with this theme, a warning will be triggered.

This commit removes those occurrences in order to avoid any
warnings.
